### PR TITLE
♻️ refactor: 올바른 session 활용을 위해 session 값에 member_id 만 저장하도록 변경

### DIFF
--- a/src/main/java/agaig/justeat/member/controller/InformationController.java
+++ b/src/main/java/agaig/justeat/member/controller/InformationController.java
@@ -5,7 +5,7 @@ import agaig.justeat.member.domain.Information;
 import agaig.justeat.member.domain.PageHandler;
 import agaig.justeat.member.dto.InfoResponseDto;
 import agaig.justeat.member.dto.InfoSaveRequestDto;
-import agaig.justeat.member.dto.MemberResponseDto;
+import agaig.justeat.member.dto.MemberUpdateResponseDto;
 import agaig.justeat.member.service.InformationService;
 import agaig.justeat.member.service.MemberService;
 import lombok.RequiredArgsConstructor;
@@ -59,8 +59,8 @@ public class InformationController {
 
     @PostMapping("/write/{member_id}")
     public String writeSave(@PathVariable Long member_id, InfoSaveRequestDto requestDto) {
-        MemberResponseDto memberResponseDto = memberService.findInfoById(member_id);
-        requestDto.setWriter(memberResponseDto.getName());
+        MemberUpdateResponseDto memberUpdateResponseDto = memberService.findInfoById(member_id);
+        requestDto.setWriter(memberUpdateResponseDto.getName());
         requestDto.setMember_id(member_id);
         informationService.write(requestDto);
         return "redirect:/info/list";

--- a/src/main/java/agaig/justeat/member/controller/MainController.java
+++ b/src/main/java/agaig/justeat/member/controller/MainController.java
@@ -2,6 +2,7 @@ package agaig.justeat.member.controller;
 
 import agaig.justeat.member.annotation.MemberSignInCheck;
 import agaig.justeat.member.domain.Member;
+import agaig.justeat.member.dto.MemberUpdateResponseDto;
 import agaig.justeat.member.exception.SignInException;
 import agaig.justeat.member.service.MemberService;
 import lombok.RequiredArgsConstructor;
@@ -20,7 +21,9 @@ public class MainController {
     private final MemberService memberService;
 
     @GetMapping("")
-    public String main() {
+    public String main(Model model, HttpSession session) {
+        MemberUpdateResponseDto responseDto = memberService.findInfoById((Long) session.getAttribute("session"));
+        model.addAttribute("memberName", responseDto.getName());
         return "index";
     }
 

--- a/src/main/java/agaig/justeat/member/controller/MemberController.java
+++ b/src/main/java/agaig/justeat/member/controller/MemberController.java
@@ -1,7 +1,7 @@
 package agaig.justeat.member.controller;
 
 import agaig.justeat.member.annotation.MemberSignInCheck;
-import agaig.justeat.member.dto.MemberResponseDto;
+import agaig.justeat.member.dto.MemberUpdateResponseDto;
 import agaig.justeat.member.dto.MemberSaveRequestDto;
 import agaig.justeat.member.dto.MemberUpdateRequestDto;
 import agaig.justeat.member.service.MemberService;
@@ -31,9 +31,9 @@ public class MemberController {
     @PostMapping("")
     public String postSignIn(String email, String password, boolean rememberId, String toURL, HttpServletRequest request, HttpServletResponse response) {
 
-        MemberResponseDto responseDto = memberService.signIn(email, password);
+        Long member_id = memberService.signIn(email, password);
 
-        Cookie memberCookie = new Cookie("member_id", responseDto.getMember_id().toString());
+        Cookie memberCookie = new Cookie("member_id", member_id.toString());
         response.addCookie(memberCookie);
 
         Cookie idCookie = new Cookie("email", email);
@@ -43,7 +43,7 @@ public class MemberController {
         response.addCookie(idCookie);
 
         HttpSession session = request.getSession();
-        session.setAttribute("session", responseDto);
+        session.setAttribute("session", member_id);
 
         toURL = toURL == null || toURL.equals("") ? "/" : toURL;
         return "redirect:" + toURL;
@@ -78,7 +78,7 @@ public class MemberController {
     @MemberSignInCheck
     @GetMapping("/{id}")
     public String memberInfo(@PathVariable Long id, Model model) {
-        MemberResponseDto responseDto = memberService.findInfoById(id);
+        MemberUpdateResponseDto responseDto = memberService.findInfoById(id);
         model.addAttribute("updateMember", responseDto);
         return "/member/memberUpdate";
     }
@@ -88,7 +88,7 @@ public class MemberController {
     public String update(@PathVariable Long id, String password,MemberUpdateRequestDto requestDto, Model model) {
         memberService.passwordCheck(id, password);
         memberService.update(id, requestDto);
-        MemberResponseDto responseDto = memberService.findInfoById(id);
+        MemberUpdateResponseDto responseDto = memberService.findInfoById(id);
         model.addAttribute("updateMember", responseDto);
         return "/member/memberUpdate";
     }

--- a/src/main/java/agaig/justeat/member/dto/MemberUpdateResponseDto.java
+++ b/src/main/java/agaig/justeat/member/dto/MemberUpdateResponseDto.java
@@ -6,21 +6,23 @@ import lombok.NoArgsConstructor;
 
 @Getter
 @NoArgsConstructor
-public class MemberResponseDto {
+public class MemberUpdateResponseDto {
     private Long member_id;
     private String email;
     private String name;
     private String phone;
     private String address;
+    private String gender;
     private String birth;
 
     // repository 를 통해 조회한 Entity 를 DTO 로 변환 용도
-    public MemberResponseDto(Member member) {
+    public MemberUpdateResponseDto(Member member) {
         this.member_id = member.getMember_id();
         this.email = member.getEmail();
         this.name = member.getName();
         this.phone = member.getPhone();
         this.address = member.getAddress();
+        this.gender = member.getGender();
         this.birth = member.getBirth();
     }
 }

--- a/src/main/java/agaig/justeat/member/service/MemberService.java
+++ b/src/main/java/agaig/justeat/member/service/MemberService.java
@@ -1,7 +1,7 @@
 package agaig.justeat.member.service;
 
 import agaig.justeat.member.domain.Member;
-import agaig.justeat.member.dto.MemberResponseDto;
+import agaig.justeat.member.dto.MemberUpdateResponseDto;
 import agaig.justeat.member.dto.MemberSaveRequestDto;
 import agaig.justeat.member.dto.MemberUpdateRequestDto;
 import agaig.justeat.member.exception.ErrorCode;
@@ -26,12 +26,12 @@ public class MemberService {
         return memberRepository.insert(requestDto.toEntity());
     }
 
-    public MemberResponseDto signIn(String email, String password) {
+    public Long signIn(String email, String password) {
         Member member = Optional.ofNullable(memberRepository.findByEmail(email)).orElseThrow(() -> new SignInException("존재하지 않는 회원 입니다.", ErrorCode.ADMIN_NOT_FOUND));
         if (!password.equals(member.getPassword())) {
             throw new SignInException("틀린 비밀번호 입니다.", ErrorCode.ADMIN_NOT_FOUND);
         }
-        return new MemberResponseDto(member);
+        return member.getMember_id();
     }
 
     public void signInCheck(HttpSession session) {
@@ -42,7 +42,7 @@ public class MemberService {
 
     public void verify(Long member_id, HttpSession session) {
         Object sessionAttribute = session.getAttribute("session");
-        MemberResponseDto sessionMember = (MemberResponseDto) sessionAttribute;
+        MemberUpdateResponseDto sessionMember = (MemberUpdateResponseDto) sessionAttribute;
         if (!member_id.equals(sessionMember.getMember_id())) {
             throw new SignInException("잘못된 접근입니다.", ErrorCode.ADMIN_NOT_FOUND);
         }
@@ -60,8 +60,8 @@ public class MemberService {
         return memberRepository.update(requestDto.toEntity());
     }
 
-    public MemberResponseDto findInfoById(Long member_id) {
+    public MemberUpdateResponseDto findInfoById(Long member_id) {
         Member member = Optional.ofNullable(memberRepository.findById(member_id)).orElseThrow(()->new SignInException("존재하지 않는 회원 입니다.", ErrorCode.ADMIN_NOT_FOUND));
-        return new MemberResponseDto(member);
+        return new MemberUpdateResponseDto(member);
     }
 }

--- a/src/main/webapp/WEB-INF/view/index.jsp
+++ b/src/main/webapp/WEB-INF/view/index.jsp
@@ -12,7 +12,7 @@ uri="http://java.sun.com/jsp/jstl/core"%>
 />
 <c:set
   var="userName"
-  value="${sessionScope.session==null ? '' : sessionScope.session.name}"
+  value="${sessionScope.session==null ? '' : memberName}"
 />
 <html lang="ko">
   <head>
@@ -41,7 +41,7 @@ uri="http://java.sun.com/jsp/jstl/core"%>
         <c:if test="${sessionScope.session != null}">
           <a
             class="member-btn-a"
-            href="<c:url value='/members/${sessionScope.session.member_id}'/>"
+            href="<c:url value='/members/${sessionScope.session}'/>"
             >회원 정보 수정</a
           >
         </c:if>

--- a/src/main/webapp/WEB-INF/view/member/memberUpdate.jsp
+++ b/src/main/webapp/WEB-INF/view/member/memberUpdate.jsp
@@ -14,7 +14,7 @@ uri="http://java.sun.com/jsp/jstl/core"%>
          <div class="member-submit-box">
             <form
                class="member-form"
-               action="/members/${sessionScope.session.member_id}"
+               action="/members/${sessionScope.session}"
                method="post"
                onsubmit="return formCheck(this)"
             >


### PR DESCRIPTION
# #23 ♻️ refactor
## 세션에 들어가는 값 변경
- 올바른 session 활용을 위해 session 값에 member_id 만 저장하도록 변경
- (기존 MemberResponseDto -> 변경 member_id)
## MemberResponseDto 이름 변경
- MemberResponseDto 는 원래 목적대로 MemberUpdateResponseDto 로 이름 변경
- 유진 님의 요청대로 gender 값 추가
